### PR TITLE
解决错误的域名检测弹窗

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -278,7 +278,7 @@ var _hmt = _hmt || [];
 		<div id="page-height-extend" class="hidden h-[300vh]"></div>
 
 		<!-- 域名检测脚本 -->
-		<script is:inline define:vars={{officialSites: ["https://2x.nz"]}}>
+		<script is:inline define:vars={{officialSites: ["https://www.2x.nz"]}}>
 			// 域名检测功能
 			function checkDomain() {
 				try {


### PR DESCRIPTION
因为现在2x.nz将会自动重定向到www.2x.nz，但是域名检测并没有同步更改，会导致不正确的弹窗
<img width="1080" height="2376" alt="Screenshot_20250814-012634_com android systemui" src="https://github.com/user-attachments/assets/2383f33b-29b6-475c-8170-212f354742a0" />
