### PR TITLE
style(styles): 优化 markdown 样式中的文本换行处理

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -27,7 +27,9 @@
         box-decoration-break: clone;
         -webkit-box-decoration-break: clone;
         
-        display: inline-block;
+        word-break: break-all;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
     
         &:hover, &:active {
             @apply decoration-transparent;


### PR DESCRIPTION
- 删除了废弃的 -webkit-box-decoration-break 属性
- 将 display: inline-block 调整为支持更灵活的自动换行
- 添加 word-break, word-wrap 和 overflow-wrap 属性以防止文本溢出