### PR TITLE
fix(styles): 修复移动端博文卡片背景不透明问题

### DIFF
--- a/src/components/PostPage.astro
+++ b/src/components/PostPage.astro
@@ -8,7 +8,9 @@ const { page } = Astro.props;
 let delay = 0;
 const interval = 50;
 ---
-<div class="transition flex flex-col rounded-[var(--radius-large)] bg-[var(--card-bg)] py-1 md:py-0 md:bg-transparent md:gap-4 mb-4">
+
+<div class="transition flex flex-col rounded-[var(--radius-large)] bg-transparent py-1 md:py-0 md:gap-4 mb-4">
+
     {page.data.map((entry: CollectionEntry<"posts">) => (
         <PostCard
                 entry={entry}


### PR DESCRIPTION
## 问题描述
移动端博文卡片半透明效果不生效，与桌面端表现不一致。

## 修改内容
- 移除 `PostPage.astro` 中移动端的不透明背景设置
- 统一移动端和桌面端使用相同的透明背景逻辑

## 测试情况
- ✅ 桌面端半透明效果正常
- ✅ 移动端半透明效果已修复
- ✅ 背景图片加载后卡片正确显示半透明效果
### 修改前
<img width="677" height="530" alt="image" src="https://github.com/user-attachments/assets/f4a622ef-292a-47ec-ab80-bb56c2890006" />

### 修改后

<img width="682" height="541" alt="image" src="https://github.com/user-attachments/assets/091efd3c-1c57-429d-a48f-aeec44c82089" />
